### PR TITLE
Remove deprecated has_rdoc setting

### DIFF
--- a/pdf-writer.gemspec
+++ b/pdf-writer.gemspec
@@ -6,7 +6,6 @@ Gem::Specification.new do |s|
   s.email    = "ken@metaskills.net"
   s.homepage = "http://github.com/metaskills/pdf-writer/"
   s.description = "A pure Ruby PDF document creation library."
-  s.has_rdoc = true
   s.authors  = ["Austin Ziegler","Ken Collins"]
   s.autorequire       = ["pdf/writer"]
   s.require_paths     = ["lib"]


### PR DESCRIPTION
I'm seeing the following warning in our project:

```
NOTE: Gem::Specification#has_rdoc= is deprecated with no replacement. It will be removed on or after 2018-12-01.
```